### PR TITLE
Fix method not allow that generates an error

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -152,7 +152,7 @@ function buildNotAllowedMiddleware(methods) {
     return function (req, res, next) {
         if (methods.indexOf(req.method.toLowerCase()) === -1) {
             res.set('Allow', methods.join(', ').toUpperCase());
-            res.sendStatus(405).end();
+            return res.sendStatus(405).end();
         }
         next();
     };


### PR DESCRIPTION
Calling `res.sendStatus(405).end()` flushes the response, so we should not call `next()` afterwards otherwise an error might get thrown.

This is exactly what happens in some internal projects.